### PR TITLE
Import PropTypes from appropriate package

### DIFF
--- a/src/components/auth.jsx
+++ b/src/components/auth.jsx
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react'
+import React, {Component} from 'react'
+import PropTypes from 'prop-types'
 import { auth, init } from '../internals'
 
 const Auth = auth.Auth

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -24,7 +24,6 @@ const authReducer = (state = defaultState, action) => {
 			return Object.assign(newState, {
 				authenticated: true,
 				authenticating: false,
-				token: action.token
 			})
 		case ACTION.LOGIN_FAILED:
 		case ACTION.SIGNUP_FAILED:


### PR DESCRIPTION
The patch eliminates PropTypes compatibility warning for React v15.5+